### PR TITLE
Fix bugs

### DIFF
--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -1061,7 +1061,7 @@ void parseConfigKey(u16 index)
 
   #ifdef LCD_LED_PWM_CHANNEL
     case C_INDEX_BRIGHTNESS:
-      if (inLimit(config_int(), 1, ITEM_BRIGHTNESS_NUM - 1))
+      if (inLimit(config_int(), 0, ITEM_BRIGHTNESS_NUM - 1))
         infoSettings.lcd_brightness = config_int();
       if (infoSettings.lcd_brightness == 0)
         infoSettings.lcd_brightness = 1; //If someone set it to 0 set it to 1

--- a/TFT/src/User/API/flashStore.c
+++ b/TFT/src/User/API/flashStore.c
@@ -2,7 +2,7 @@
 #include "STM32_Flash.h"
 
 #define TSC_SIGN  0x20200512 // DO NOT MODIFY
-#define PARA_SIGN 0x20201101 // (YYYYMMDD) If a new setting parameter is added,
+#define PARA_SIGN 0x20201102 // (YYYYMMDD) If a new setting parameter is added,
                              // modify here and initialize the initial value
                              // in the "infoSettingsReset()" function
 

--- a/TFT/src/User/API/flashStore.c
+++ b/TFT/src/User/API/flashStore.c
@@ -243,6 +243,8 @@ void storePara(void)
   wordToByte(infoSettings.lcd_idle_brightness,        data + (index += 4));
   wordToByte(infoSettings.lcd_idle_timer,             data + (index += 4));
 
+  wordToByte(infoSettings.sequential_mode,            data + (index += 4));
+
   wordToByte(infoSettings.serial_alwaysOn,            data + (index += 4));
   wordToByte(infoSettings.marlin_mode_bg_color,       data + (index += 4));
   wordToByte(infoSettings.marlin_mode_font_color,     data + (index += 4));

--- a/TFT/src/User/API/sequential_mode.c
+++ b/TFT/src/User/API/sequential_mode.c
@@ -1,5 +1,4 @@
 #include "sequential_mode.h"
-
 #include "includes.h"
 
 uint8_t prevPixelColor = 0;
@@ -31,13 +30,15 @@ void setSequentialModeColor(void) {
       //Restore colors to default value
       prevPixelColor = 0;
 
-      //Turn of neopixels and set knob led back to default
+      //Turn off neopixels and set knob led back to default
       storeCmd("M150 R0 U0 B0");
       #ifdef LED_COLOR_PIN
-        if(infoSettings.knob_led_idle && lcd_dim.dimmed)
-          WS2812_Send_DAT(LED_OFF);
-        else
-          WS2812_Send_DAT(led_color[infoSettings.knob_led_color]);
+        #ifdef LCD_LED_PWM_CHANNEL
+          if(infoSettings.knob_led_idle && lcd_dim.dimmed)
+            WS2812_Send_DAT(led_color[LED_OFF]);
+          else
+        #endif
+            WS2812_Send_DAT(led_color[infoSettings.knob_led_color]);
       #endif
     }
 
@@ -54,7 +55,7 @@ void setSequentialModeColor(void) {
     if (hotendTargetTemp == 0 && bedTargetTemp == 0)
       return;  //No temperature set "yet". Do nothing.
 
-    long newLedValue = 0;
+    uint8_t newLedValue = 0;
     if (hotendTargetTemp > 0 && bedTargetTemp > 0 &&
         bedCurrentTemp >= bedTargetTemp - 5) {
       //Only use total temperature when hotend and bed heat up at the same time
@@ -91,10 +92,12 @@ void setSequentialModeColor(void) {
       storeCmd("M150 R255 U255 B255");
 
       #ifdef LED_COLOR_PIN
-        if(infoSettings.knob_led_idle && lcd_dim.dimmed)
-          WS2812_Send_DAT(led_color[LED_OFF]);
-        else
-          WS2812_Send_DAT(led_color[infoSettings.knob_led_color]);
+        #ifdef LCD_LED_PWM_CHANNEL
+          if(infoSettings.knob_led_idle && lcd_dim.dimmed)
+            WS2812_Send_DAT(led_color[LED_OFF]);
+          else
+        #endif
+            WS2812_Send_DAT(led_color[infoSettings.knob_led_color]);
       #endif
 
       //Set the flag heating done to true

--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -74,9 +74,9 @@ typedef enum
   SKEY_ACK_NOTIFICATION,
   #ifdef LED_COLOR_PIN
     SKEY_KNOB,
-  #ifdef LCD_LED_PWM_CHANNEL
-    SKEY_KNOB_LED_IDLE,
-  #endif
+    #ifdef LCD_LED_PWM_CHANNEL
+      SKEY_KNOB_LED_IDLE,
+    #endif
   #endif
   #ifdef LCD_LED_PWM_CHANNEL
     SKEY_LCD_BRIGHTNESS,
@@ -118,16 +118,16 @@ LISTITEM settingPage[SKEY_COUNT] = {
   {ICONCHAR_BLANK,      LIST_CUSTOMVALUE,   LABEL_ACK_NOTIFICATION,         LABEL_DYNAMIC},
   #ifdef LED_COLOR_PIN
     {ICONCHAR_BLANK,      LIST_CUSTOMVALUE,   LABEL_KNOB_LED,                 LABEL_OFF},
-  #ifdef LCD_LED_PWM_CHANNEL
-    {ICONCHAR_BLANK,      LIST_TOGGLE,        LABEL_KNOB_LED_IDLE,            LABEL_BACKGROUND},
-  #endif
+    #ifdef LCD_LED_PWM_CHANNEL
+      {ICONCHAR_BLANK,      LIST_TOGGLE,        LABEL_KNOB_LED_IDLE,            LABEL_BACKGROUND},
+    #endif
   #endif
   #ifdef LCD_LED_PWM_CHANNEL
     {ICONCHAR_BLANK,      LIST_CUSTOMVALUE,   LABEL_LCD_BRIGHTNESS,           LABEL_DYNAMIC},
     {ICONCHAR_BLANK,      LIST_CUSTOMVALUE,   LABEL_LCD_BRIGHTNESS_DIM,       LABEL_DYNAMIC},
     {ICONCHAR_BLANK,      LIST_CUSTOMVALUE,   LABEL_LCD_DIM_IDLE_TIMER,       LABEL_DYNAMIC},
   #endif
-    {ICONCHAR_BLANK,      LIST_TOGGLE,        LABEL_SEQUENTIAL_MODE,          LABEL_BACKGROUND},
+  {ICONCHAR_BLANK,      LIST_TOGGLE,        LABEL_SEQUENTIAL_MODE,          LABEL_BACKGROUND},
   #ifdef ST7920_SPI
     {ICONCHAR_BLANK,      LIST_TOGGLE,        LABEL_ST7920_FULLSCREEN,        LABEL_OFF},
   #endif
@@ -227,13 +227,13 @@ void updateFeatureSettings(uint8_t key_val)
         WS2812_Send_DAT(led_color[infoSettings.knob_led_color]);
         break;
 
-    #ifdef LCD_LED_PWM_CHANNEL
-      case SKEY_KNOB_LED_IDLE:
-        infoSettings.knob_led_idle = (infoSettings.knob_led_idle + 1) % TOGGLE_NUM;
-        settingPage[item_index].icon = toggleitem[infoSettings.knob_led_idle];
-        break;
-    #endif //LCD_LED_PWM_CHANNEL
-    #endif
+      #ifdef LCD_LED_PWM_CHANNEL
+        case SKEY_KNOB_LED_IDLE:
+          infoSettings.knob_led_idle = (infoSettings.knob_led_idle + 1) % TOGGLE_NUM;
+          settingPage[item_index].icon = toggleitem[infoSettings.knob_led_idle];
+          break;
+      #endif //LCD_LED_PWM_CHANNEL
+    #endif //LED_COLOR_PIN
 
     case SKEY_RESET_SETTINGS:
       setDialogText(LABEL_SETTING_RESET, LABEL_RESET_SETTINGS_INFO, LABEL_CONFIRM, LABEL_CANCEL);
@@ -362,17 +362,20 @@ void loadFeatureSettings(){
 
       case SKEY_RESET_SETTINGS:
         break;
+
       #ifdef LED_COLOR_PIN
         case SKEY_KNOB:
           settingPage[item_index].valueLabel = itemLedcolor[infoSettings.knob_led_color];
           featureSettingsItems.items[i] = settingPage[item_index];
           break;
+
         #ifdef LCD_LED_PWM_CHANNEL
-        case SKEY_KNOB_LED_IDLE:
-          settingPage[item_index].icon = toggleitem[infoSettings.knob_led_idle];
-          break;
+          case SKEY_KNOB_LED_IDLE:
+            settingPage[item_index].icon = toggleitem[infoSettings.knob_led_idle];
+            break;
         #endif
       #endif
+
       #ifdef LCD_LED_PWM_CHANNEL
         case SKEY_LCD_BRIGHTNESS:
         {
@@ -391,7 +394,7 @@ void loadFeatureSettings(){
         case SKEY_LCD_DIM_IDLE_TIMER:
           settingPage[item_index].valueLabel = itemDimTime[infoSettings.lcd_idle_timer];
           break;
-      #endif //PS_ON_PIN
+      #endif //LCD_LED_PWM_CHANNEL
 
       case SKEY_SEQUENTIAL_MODE:
         settingPage[item_index].icon = toggleitem[infoSettings.sequential_mode];


### PR DESCRIPTION
- Add the missing line to save `infoSettings.sequential_mode`  in **flashStore.c** which is resulting in the wrong index when settings are loaded after boot.
- add check for `LCD_LED_PWM_CHANNEL` in **sequential_mode.c**